### PR TITLE
fix: release workflow not triggering for CLI version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".changeset/**"
       - "package.json"
+      - "apps/cli/package.json"
 
 concurrency:
   group: release


### PR DESCRIPTION
## Problem
Release workflow wasn't triggering when CLI version was bumped because it only monitors root `package.json` but CLI version is in `apps/cli/package.json`.

## Solution  
Add `apps/cli/package.json` to the workflow trigger paths.

## Testing
After merge, CLI version bumps will automatically trigger releases.

Fixes the issue where v0.6.2 didn't trigger release workflow.