### PR TITLE
fix: create CLI-specific README and bump to v0.6.6

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,130 @@
+# pcu
+
+A powerful CLI tool for managing pnpm workspace catalog dependencies with ease.
+
+## 🚀 Quick Start
+
+### Installation
+
+```bash
+# Install globally
+npm install -g pcu
+
+# Or use with pnpm
+pnpm add -g pcu
+
+# Or use legacy package name
+npm install -g pnpm-catalog-updates
+```
+
+### Usage
+
+```bash
+# Check for outdated catalog dependencies
+pcu check
+# or
+pcu -c
+
+# Update catalog dependencies interactively
+pcu update --interactive
+# or
+pcu -i
+
+# Update to latest versions
+pcu update
+# or
+pcu -u
+
+# Analyze impact of updates
+pcu analyze
+# or
+pcu -a
+
+# Show workspace information
+pcu workspace
+# or
+pcu -s
+```
+
+## 📋 Commands
+
+| Command         | Shorthand | Description                                     |
+| --------------- | --------- | ----------------------------------------------- |
+| `pcu check`     | `pcu -c`  | Check for outdated catalog dependencies         |
+| `pcu update`    | `pcu -u`  | Update catalog dependencies                     |
+| `pcu analyze`   | `pcu -a`  | Analyze impact of dependency updates            |
+| `pcu workspace` | `pcu -s`  | Show workspace information and validation       |
+| `pcu init`      |           | Initialize workspace with catalog configuration |
+| `pcu help`      | `pcu -h`  | Display help information                        |
+
+## 🎯 Common Examples
+
+```bash
+# Interactive update with backup
+pcu update --interactive --backup
+
+# Update only minor versions
+pcu update --target minor
+
+# Check specific catalog
+pcu check --catalog node18
+
+# Analyze before updating
+pcu analyze default react
+
+# Validate workspace
+pcu workspace --validate
+
+# Dry run update
+pcu update --dry-run
+```
+
+## ⚙️ Options
+
+### Global Options
+
+- `--help, -h`: Show help
+- `--version, -v`: Show version
+- `--verbose`: Enable verbose logging
+- `--quiet`: Suppress non-error output
+
+### Update Options
+
+- `--interactive, -i`: Interactive mode
+- `--dry-run, -d`: Show what would be updated without making changes
+- `--backup, -b`: Create backup before updating
+- `--target <level>`: Update target (patch|minor|major|latest)
+- `--catalog <name>`: Target specific catalog
+
+## 📁 Configuration
+
+Create a `.pcurc.json` file in your project root:
+
+```json
+{
+  "catalogs": ["default", "node18", "dev"],
+  "updateTarget": "minor",
+  "backup": true,
+  "interactive": false
+}
+```
+
+## 🔧 Requirements
+
+- Node.js >= 22.0.0
+- pnpm workspace with catalog configuration
+- pnpm-workspace.yaml with catalog entries
+
+## 📚 Documentation
+
+For complete documentation, visit:
+[pnpm-catalog-updates](https://github.com/houko/pnpm-catalog-updates#readme)
+
+## 🤝 Contributing
+
+Found a bug or want to contribute? Visit our
+[GitHub repository](https://github.com/houko/pnpm-catalog-updates).
+
+## 📄 License
+
+MIT © [Evan Hu](https://github.com/houko)

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcu",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "CLI application for pnpm-catalog-updates",
   "type": "module",
   "main": "./dist/index.js",
@@ -14,9 +14,7 @@
     "dist",
     "bin",
     "src",
-    "../../README.md",
-    "../../README.ja.md",
-    "../../README.zh-CN.md"
+    "README.md"
   ],
   "scripts": {
     "build": "tsup && pnpm run build:bin",


### PR DESCRIPTION
## 🎯 Problem
The CLI package was using the same README as the main project, which is incorrect:
- **Project README**: Should focus on development, architecture, contribution
- **CLI README**: Should focus on installation, commands, usage examples

## ✅ Solution
- ✅ **CLI-Specific README**: Created  focused on CLI usage
- ✅ **Clean Documentation**: Removed project-level README from CLI package
- ✅ **Professional CLI Docs**: Installation, commands table, examples, configuration
- ✅ **Version Bump**: 0.6.5 → 0.6.6

## 📚 New CLI README Content
- 🚀 **Quick Start**: Installation with npm/pnpm
- 📋 **Commands Table**: All CLI commands with shortcuts
- 🎯 **Examples**: Common usage patterns
- ⚙️ **Options**: Detailed flag explanations  
- 📁 **Configuration**: .pcurc.json setup
- 🔧 **Requirements**: Node.js and pnpm versions

## 📦 Result After Publishing
Both packages will now have appropriate CLI documentation:
- `pcu@0.6.6` - with CLI-focused README
- `pnpm-catalog-updates@0.6.6` - same content for compatibility

## 🔗 Links
- Users installing CLI packages will see proper usage instructions
- Links back to main project repository for full documentation