### PR TITLE
Fix docs TypeScript error and update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main, develop]
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pcu",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "CLI application for pnpm-catalog-updates",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Fixed SVG type declaration conflict in docs app that was causing TypeScript errors
- Updated CI workflow to only run on main branch pushes (removed develop branch)  
- Bumped CLI version from 0.6.8 to 0.6.9

## Test plan
- [x] TypeScript checks pass for all packages
- [x] Docs app builds without errors
- [x] CI workflow validates correctly
