### PR TITLE
fix: resolve ESM loader error on Windows with Node.js v22

### DIFF
--- a/apps/cli/bin/pcu.js
+++ b/apps/cli/bin/pcu.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 
-import { fileURLToPath } from 'url';
 import path from 'path';
+import url, { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Import and run the CLI
-const { main } = await import(path.join(__dirname, '..', 'dist', 'index.js'));
+const modulePath = url.pathToFileURL(path.join(__dirname, '..', 'dist', 'index.js')).href;
+const { main } = await import(modulePath);
 
 main().catch((error) => {
   console.error('❌ Error:', error.message);

--- a/scripts/build-bin.js
+++ b/scripts/build-bin.js
@@ -29,12 +29,14 @@ async function buildBin() {
 
 import { fileURLToPath } from 'url';
 import path from 'path';
+import url from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 // Import and run the CLI
-const { main } = await import(path.join(__dirname, '..', 'dist', 'index.js'));
+const modulePath = url.pathToFileURL(path.join(__dirname, '..', 'dist', 'index.js')).href;
+const { main } = await import(modulePath);
 
 main().catch((error) => {
   console.error('❌ Error:', error.message);


### PR DESCRIPTION
This pull request makes a small but important change to the way the CLI entry point is imported in `scripts/build-bin.js`. Instead of importing the compiled CLI using a filesystem path, it now uses a file URL, which improves compatibility with the ES module loader.

* Updated the dynamic import of `dist/index.js` to use a file URL (`url.pathToFileURL`) instead of a path string, ensuring correct module resolution in ES module environments.