### PR TITLE
fix: pass --target option to catalog filtering logic (#81)

### DIFF
--- a/packages/core/src/application/services/catalogCheckService.ts
+++ b/packages/core/src/application/services/catalogCheckService.ts
@@ -78,8 +78,16 @@ export class CatalogCheckService {
   async checkOutdatedDependencies(options: CheckOptions = {}): Promise<OutdatedReport> {
     const workspacePath = WorkspacePath.fromString(options.workspacePath || process.cwd())
 
-    // Load configuration
+    // Load configuration and merge CLI options into config defaults
+    // This ensures --target and other CLI options are passed to the filtering logic
     const config = await ConfigLoader.loadConfig(workspacePath.toString())
+    const configWithOptions: PackageFilterConfig = {
+      ...config,
+      defaults: {
+        ...config.defaults,
+        ...options,
+      },
+    }
 
     // Load workspace (getByPath throws WorkspaceNotFoundError if not found)
     const workspace = await this.workspaceRepository.getByPath(workspacePath)
@@ -101,7 +109,10 @@ export class CatalogCheckService {
     }
 
     // Get filtered packages from all catalogs
-    const filteredPackagesByCatalog = this.getFilteredPackagesFromCatalogs(catalogsToCheck, config)
+    const filteredPackagesByCatalog = this.getFilteredPackagesFromCatalogs(
+      catalogsToCheck,
+      configWithOptions
+    )
 
     // Calculate total packages across all catalogs
     let totalPackages = 0


### PR DESCRIPTION
## Summary

Fixed #81: The `--target` option was not being passed to the catalog filtering logic, causing it to always default to `latest`.

## Changes

- Merge CLI options (including `target`) into config defaults before passing to `getFilteredPackagesFromCatalogs`
- This ensures the filtering logic respects the `--target` CLI option

## Testing

- [ ] Test with `pcu check --target minor` to verify only minor updates are shown

Closes #81