### PR TITLE
fix: run release after prepared manual version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,12 +91,26 @@ jobs:
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             echo "⚠️ **Dry run only**: no commit or tag was pushed." >> $GITHUB_STEP_SUMMARY
           else
-            echo "✅ **Release commit and tag pushed.** The tag-triggered release workflow will publish the packages." >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Release commit and tag pushed.** The release job in this workflow will publish the packages." >> $GITHUB_STEP_SUMMARY
           fi
 
   release:
     name: Release
-    if: ${{ github.event_name == 'push' || github.event.inputs.release_type == 'current' }}
+    needs: prepare_release
+    if: >-
+      ${{
+        always() &&
+        (
+          github.event_name == 'push' ||
+          github.event.inputs.release_type == 'current' ||
+          (
+            github.event_name == 'workflow_dispatch' &&
+            github.event.inputs.release_type != 'current' &&
+            github.event.inputs.dry_run != 'true' &&
+            needs.prepare_release.result == 'success'
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -108,6 +122,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Manual minor/major/patch releases need the freshly pushed release commit,
+          # because tag pushes created by GITHUB_TOKEN do not trigger a second workflow run.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_type != 'current' && github.ref_name || github.ref }}
 
       - name: Setup Environment
         uses: ./.github/actions/setup


### PR DESCRIPTION
## Summary
- keep manual `minor`/`major`/`patch` releases publishing in the same workflow run
- stop depending on a tag-push follow-up workflow that `GITHUB_TOKEN` cannot trigger
- checkout the freshly pushed release commit before publishing

## Root Cause
The prepare job pushed a release tag with `GITHUB_TOKEN`, but that tag push did not trigger a second `Release` workflow run. The original workflow skipped the `Release` job in the manual `minor`/`major`/`patch` run, so npm publish and GitHub Release creation never happened.

## Validation
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "yaml ok"'\n- workflow logic reviewed against failed run 23116338642