### PR TITLE
docs: update release process guide

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,12 +91,26 @@ jobs:
           if [[ "${{ github.event.inputs.dry_run }}" == "true" ]]; then
             echo "⚠️ **Dry run only**: no commit or tag was pushed." >> $GITHUB_STEP_SUMMARY
           else
-            echo "✅ **Release commit and tag pushed.** The tag-triggered release workflow will publish the packages." >> $GITHUB_STEP_SUMMARY
+            echo "✅ **Release commit and tag pushed.** The release job in this workflow will publish the packages." >> $GITHUB_STEP_SUMMARY
           fi
 
   release:
     name: Release
-    if: ${{ github.event_name == 'push' || github.event.inputs.release_type == 'current' }}
+    needs: prepare_release
+    if: >-
+      ${{
+        always() &&
+        (
+          github.event_name == 'push' ||
+          github.event.inputs.release_type == 'current' ||
+          (
+            github.event_name == 'workflow_dispatch' &&
+            github.event.inputs.release_type != 'current' &&
+            github.event.inputs.dry_run != 'true' &&
+            needs.prepare_release.result == 'success'
+          )
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -108,6 +122,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Manual minor/major/patch releases need the freshly pushed release commit,
+          # because tag pushes created by GITHUB_TOKEN do not trigger a second workflow run.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release_type != 'current' && github.ref_name || github.ref }}
 
       - name: Setup Environment
         uses: ./.github/actions/setup

--- a/apps/docs/src/content/de/development.mdx
+++ b/apps/docs/src/content/de/development.mdx
@@ -389,12 +389,7 @@ pcu -u --dry-run
 
 ### Release-Prozess
 
-1. **Version aktualisieren** mit Changesets:
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. **Release-Notizen vorbereiten** in `apps/cli/CHANGELOG.md` unter `## Unreleased`.
 
 2. **Bauen und testen**:
 
@@ -404,10 +399,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **Veröffentlichen** (nur Maintainer):
-   ```bash
-   pnpm publish -r
-   ```
+3. **Den GitHub-Actions-Workflow `Release` ausführen** (nur Maintainer):
+   - `patch`, `minor`, `major`: erhöhen die CLI-Version, committen die Release-Änderungen, erstellen den Tag, veröffentlichen `pcu` und `pnpm-catalog-updates` und erzeugen den GitHub Release in einem Lauf
+   - `current`: veröffentlicht die Version, die bereits im Repository committed ist
+   - `dry_run: true`: prüft den Ablauf ohne Veröffentlichung
 
 ## Hilfe erhalten
 

--- a/apps/docs/src/content/en/development.mdx
+++ b/apps/docs/src/content/en/development.mdx
@@ -389,12 +389,7 @@ pcu -u --dry-run
 
 ### Release Process
 
-1. **Update version** using changesets:
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. **Prepare release notes** in `apps/cli/CHANGELOG.md` under `## Unreleased`.
 
 2. **Build and test**:
 
@@ -404,10 +399,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **Publish** (maintainers only):
-   ```bash
-   pnpm publish -r
-   ```
+3. **Run the GitHub Actions `Release` workflow** (maintainers only):
+   - `patch`, `minor`, `major`: bump the CLI version, commit the release changes, create the tag, publish `pcu` and `pnpm-catalog-updates`, and create the GitHub Release in one run
+   - `current`: publish the version that is already committed in the repository
+   - `dry_run: true`: validate the flow without publishing
 
 ## Getting Help
 

--- a/apps/docs/src/content/es/development.mdx
+++ b/apps/docs/src/content/es/development.mdx
@@ -389,12 +389,7 @@ pcu -u --dry-run
 
 ### Proceso de Lanzamiento
 
-1. **Actualizar versión** usando changesets:
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. **Preparar las notas de la release** en `apps/cli/CHANGELOG.md` bajo `## Unreleased`.
 
 2. **Construir y probar**:
 
@@ -404,10 +399,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **Publicar** (solo mantenedores):
-   ```bash
-   pnpm publish -r
-   ```
+3. **Ejecutar el workflow `Release` de GitHub Actions** (solo mantenedores):
+   - `patch`, `minor`, `major`: incrementan la versión del CLI, hacen commit de los cambios de release, crean la etiqueta, publican `pcu` y `pnpm-catalog-updates` y crean la GitHub Release en una sola ejecución
+   - `current`: publica la versión que ya está confirmada en el repositorio
+   - `dry_run: true`: valida el flujo sin publicar
 
 ## Obtener Ayuda
 

--- a/apps/docs/src/content/fr/development.mdx
+++ b/apps/docs/src/content/fr/development.mdx
@@ -389,12 +389,7 @@ pcu -u --dry-run
 
 ### Processus de Release
 
-1. **Mettre à jour la version** en utilisant changesets :
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. **Préparer les notes de release** dans `apps/cli/CHANGELOG.md` sous `## Unreleased`.
 
 2. **Construire et tester** :
 
@@ -404,10 +399,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **Publier** (mainteneurs uniquement) :
-   ```bash
-   pnpm publish -r
-   ```
+3. **Exécuter le workflow GitHub Actions `Release`** (mainteneurs uniquement) :
+   - `patch`, `minor`, `major` : incrémentent la version du CLI, commitent les changements de release, créent le tag, publient `pcu` et `pnpm-catalog-updates`, puis créent la GitHub Release dans la même exécution
+   - `current` : publie la version déjà commitée dans le dépôt
+   - `dry_run: true` : valide le flux sans publier
 
 ## Obtenir de l'Aide
 

--- a/apps/docs/src/content/ja/development.mdx
+++ b/apps/docs/src/content/ja/development.mdx
@@ -389,12 +389,7 @@ pcu -u --dry-run
 
 ### リリースプロセス
 
-1. **changesetsでバージョンを更新**：
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. **`apps/cli/CHANGELOG.md` の `## Unreleased` にリリースノートを追加**します。
 
 2. **ビルドとテスト**：
 
@@ -404,10 +399,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **公開**（メンテナーのみ）：
-   ```bash
-   pnpm publish -r
-   ```
+3. **GitHub Actions の `Release` ワークフローを実行**します（メンテナーのみ）：
+   - `patch`、`minor`、`major`：CLI バージョンを更新し、release 用のコミットとタグを作成し、`pcu` と `pnpm-catalog-updates` を公開し、GitHub Release まで 1 回で実行します
+   - `current`：リポジトリにすでにコミット済みのバージョンをそのまま公開します
+   - `dry_run: true`：公開せずにフローだけ検証します
 
 ## ヘルプの取得
 

--- a/apps/docs/src/content/ko/development.mdx
+++ b/apps/docs/src/content/ko/development.mdx
@@ -389,12 +389,7 @@ pcu -u --dry-run
 
 ### 릴리스 프로세스
 
-1. **changeset을 사용하여 버전 업데이트**:
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. `apps/cli/CHANGELOG.md` 의 `## Unreleased` 아래에 **릴리스 노트**를 정리합니다.
 
 2. **빌드 및 테스트**:
 
@@ -404,10 +399,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **배포** (관리자만):
-   ```bash
-   pnpm publish -r
-   ```
+3. **GitHub Actions `Release` 워크플로를 실행**합니다 (관리자만):
+   - `patch`, `minor`, `major`: CLI 버전을 올리고, 릴리스 변경을 커밋하고, 태그를 만들고, `pcu` 와 `pnpm-catalog-updates` 를 배포하고, GitHub Release 까지 한 번에 처리합니다
+   - `current`: 저장소에 이미 커밋된 버전을 그대로 배포합니다
+   - `dry_run: true`: 실제 배포 없이 흐름만 검증합니다
 
 ## 도움 받기
 

--- a/apps/docs/src/content/zh/development.mdx
+++ b/apps/docs/src/content/zh/development.mdx
@@ -388,12 +388,7 @@ pcu -u --dry-run
 
 ### 发布流程
 
-1. **使用 changesets 更新版本**：
-
-   ```bash
-   pnpm changeset
-   pnpm changeset version
-   ```
+1. **先在 `apps/cli/CHANGELOG.md` 的 `## Unreleased` 下整理发布说明**。
 
 2. **构建和测试**：
 
@@ -403,10 +398,10 @@ pcu -u --dry-run
    pnpm test:e2e
    ```
 
-3. **发布**（仅维护者）：
-   ```bash
-   pnpm publish -r
-   ```
+3. **运行 GitHub Actions 的 `Release` 工作流**（仅维护者）：
+   - `patch`、`minor`、`major`：自动升级 CLI 版本、提交 release 变更、创建 tag、发布 `pcu` 和 `pnpm-catalog-updates`，并在同一次运行里创建 GitHub Release
+   - `current`：发布仓库里已经提交好的当前版本
+   - `dry_run: true`：只验证流程，不实际发布
 
 ## 获取帮助
 

--- a/apps/docs/src/generated/search-index.ts
+++ b/apps/docs/src/generated/search-index.ts
@@ -1258,9 +1258,12 @@ export const searchData = {
           [
             "Lokale Tests",
             "Release-Prozess",
-            "Version aktualisieren mit Changesets:",
+            "Release-Notizen vorbereiten in apps/cli/CHANGELOG.md unter ## Unreleased.",
             "Bauen und testen:",
-            "Veröffentlichen (nur Maintainer):"
+            "Den GitHub-Actions-Workflow Release ausführen (nur Maintainer):",
+            "patch, minor, major: erhöhen die CLI-Version, committen die Release-Änderungen, erstellen den Tag, veröffentlichen pcu und pnpm-catalog-updates und erzeugen den GitHub Release in einem Lauf",
+            "current: veröffentlicht die Version, die bereits im Repository committed ist",
+            "dry_run: true: prüft den Ablauf ohne Veröffentlichung"
           ]
         ],
         [
@@ -4288,9 +4291,12 @@ export const searchData = {
           [
             "Local Testing",
             "Release Process",
-            "Update version using changesets:",
+            "Prepare release notes in apps/cli/CHANGELOG.md under ## Unreleased.",
             "Build and test:",
-            "Publish (maintainers only):"
+            "Run the GitHub Actions Release workflow (maintainers only):",
+            "patch, minor, major: bump the CLI version, commit the release changes, create the tag, publish pcu and pnpm-catalog-updates, and create the GitHub Release in one run",
+            "current: publish the version that is already committed in the repository",
+            "dry_run: true: validate the flow without publishing"
           ]
         ],
         [
@@ -7174,9 +7180,12 @@ export const searchData = {
           [
             "Pruebas Locales",
             "Proceso de Lanzamiento",
-            "Actualizar versión usando changesets:",
+            "Preparar las notas de la release en apps/cli/CHANGELOG.md bajo ## Unreleased.",
             "Construir y probar:",
-            "Publicar (solo mantenedores):"
+            "Ejecutar el workflow Release de GitHub Actions (solo mantenedores):",
+            "patch, minor, major: incrementan la versión del CLI, hacen commit de los cambios de release, crean la etiqueta, publican pcu y pnpm-catalog-updates y crean la GitHub Release en una sola ejecución",
+            "current: publica la versión que ya está confirmada en el repositorio",
+            "dry_run: true: valida el flujo sin publicar"
           ]
         ],
         [
@@ -10178,9 +10187,12 @@ export const searchData = {
           [
             "Test Local",
             "Processus de Release",
-            "Mettre à jour la version en utilisant changesets :",
+            "Préparer les notes de release dans apps/cli/CHANGELOG.md sous ## Unreleased.",
             "Construire et tester :",
-            "Publier (mainteneurs uniquement) :"
+            "Exécuter le workflow GitHub Actions Release (mainteneurs uniquement) :",
+            "patch, minor, major : incrémentent la version du CLI, commitent les changements de release, créent le tag, publient pcu et pnpm-catalog-updates, puis créent la GitHub Release dans la même exécution",
+            "current : publie la version déjà commitée dans le dépôt",
+            "dry_run: true : valide le flux sans publier"
           ]
         ],
         [
@@ -13009,9 +13021,12 @@ export const searchData = {
           [
             "ローカルテスト",
             "リリースプロセス",
-            "changesetsでバージョンを更新：",
+            "apps/cli/CHANGELOG.md の ## Unreleased にリリースノートを追加します。",
             "ビルドとテスト：",
-            "公開（メンテナーのみ）："
+            "GitHub Actions の Release ワークフローを実行します（メンテナーのみ）：",
+            "patch、minor、major：CLI バージョンを更新し、release 用のコミットとタグを作成し、pcu と pnpm-catalog-updates を公開し、GitHub Release まで 1 回で実行します",
+            "current：リポジトリにすでにコミット済みのバージョンをそのまま公開します",
+            "dry_run: true：公開せずにフローだけ検証します"
           ]
         ],
         [
@@ -16035,9 +16050,12 @@ export const searchData = {
           [
             "로컬 테스트",
             "릴리스 프로세스",
-            "changeset을 사용하여 버전 업데이트:",
+            "apps/cli/CHANGELOG.md 의 ## Unreleased 아래에 릴리스 노트를 정리합니다.",
             "빌드 및 테스트:",
-            "배포 (관리자만):"
+            "GitHub Actions Release 워크플로를 실행합니다 (관리자만):",
+            "patch, minor, major: CLI 버전을 올리고, 릴리스 변경을 커밋하고, 태그를 만들고, pcu 와 pnpm-catalog-updates 를 배포하고, GitHub Release 까지 한 번에 처리합니다",
+            "current: 저장소에 이미 커밋된 버전을 그대로 배포합니다",
+            "dry_run: true: 실제 배포 없이 흐름만 검증합니다"
           ]
         ],
         [
@@ -18865,9 +18883,12 @@ export const searchData = {
           [
             "本地测试",
             "发布流程",
-            "使用 changesets 更新版本：",
+            "先在 apps/cli/CHANGELOG.md 的 ## Unreleased 下整理发布说明。",
             "构建和测试：",
-            "发布（仅维护者）："
+            "运行 GitHub Actions 的 Release 工作流（仅维护者）：",
+            "patch、minor、major：自动升级 CLI 版本、提交 release 变更、创建 tag、发布 pcu 和 pnpm-catalog-updates，并在同一次运行里创建 GitHub Release",
+            "current：发布仓库里已经提交好的当前版本",
+            "dry_run: true：只验证流程，不实际发布"
           ]
         ],
         [


### PR DESCRIPTION
## Summary
- replace the outdated changesets/manual publish instructions in `development.mdx`
- document the current GitHub Actions `Release` workflow with `current`, `patch`, `minor`, `major`, and `dry_run`
- regenerate the docs search index so search matches the new release guidance

## Validation
- pnpm --filter @pcu/docs generate:search
- pnpm --filter @pcu/docs typecheck