### PR TITLE
docs: clarify release tag script flow

### DIFF
--- a/scripts/release-tag.cjs
+++ b/scripts/release-tag.cjs
@@ -79,7 +79,9 @@ function main() {
   console.log(`   1. Build the packages`)
   console.log(`   2. Publish to NPM (pcu & pnpm-catalog-updates)`)
   console.log(`   3. Create GitHub Release`)
-  console.log(`\nℹ️  For patch/minor/major bumps, use the GitHub Actions "Release" workflow instead.`)
+  console.log(
+    `\nℹ️  For patch/minor/major bumps, use the GitHub Actions "Release" workflow instead.`
+  )
   console.log(`\n🔗 Monitor at: https://github.com/yldm-tech/pnpm-catalog-updates/actions`)
 }
 

--- a/scripts/release-tag.cjs
+++ b/scripts/release-tag.cjs
@@ -9,7 +9,11 @@
  * This script:
  * 1. Reads version from apps/cli/package.json
  * 2. Creates a git tag (v{version})
- * 3. Pushes the tag to trigger release workflow
+ * 3. Pushes the tag for the tag-based release flow
+ *
+ * Note:
+ * - Use this script only when the target version is already committed
+ * - For patch/minor/major releases, use the GitHub Actions "Release" workflow
  */
 
 const fs = require('node:fs')
@@ -71,10 +75,11 @@ function main() {
   run(`git push origin ${tagName}`)
 
   console.log(`\n✅ Release tag ${tagName} pushed successfully!`)
-  console.log(`\n📋 GitHub Actions will now:`)
+  console.log(`\n📋 GitHub Actions will now run the tag-based release flow:`)
   console.log(`   1. Build the packages`)
   console.log(`   2. Publish to NPM (pcu & pnpm-catalog-updates)`)
   console.log(`   3. Create GitHub Release`)
+  console.log(`\nℹ️  For patch/minor/major bumps, use the GitHub Actions "Release" workflow instead.`)
   console.log(`\n🔗 Monitor at: https://github.com/yldm-tech/pnpm-catalog-updates/actions`)
 }
 


### PR DESCRIPTION
## Summary
- clarify that `scripts/release-tag.cjs` is for tag-based releases of an already committed version
- stop implying that patch/minor/major manual releases rely on a separate tag-triggered workflow
- point maintainers to the GitHub Actions `Release` workflow for version bumps

## Validation
- node --check scripts/release-tag.cjs
- pnpm typecheck