### PR TITLE
feat: add engines.pnpm constraint (#106)

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
   },
   "homepage": "https://pcu-cli.dev",
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.13.0",
+    "pnpm": ">=10 <12"
   },
   "packageManager": "pnpm@10.26.1+sha512.664074abc367d2c9324fdc18037097ce0a8f126034160f709928e9e9f95d98714347044e5c3164d65bd5da6c59c6be362b107546292a8eecb7999196e5ce58fa",
   "type": "module",


### PR DESCRIPTION
## Enhancement: Add engines.pnpm constraint

### Changes

- Add `engines.pnpm: ">=10 <12"` to root `package.json`
- Ensures pnpm 11 compatibility checks are enforced
- Blocks silently breaking with pnpm 12+

### Testing

- CI validates pnpm version constraints
- Manual: `pnpm install` respects engines field

### References

- Issue: #106