### PR TITLE
feat: pnpm v11 compatibility (#108)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,3 +118,34 @@ jobs:
       - name: Build example workspace
         working-directory: apps/example
         run: pnpm build
+
+  pnpm-v11-compat:
+    name: pnpm v11 Compatibility (Node 22)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.13.0'
+
+      - name: Setup pnpm v11
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+
+      - name: Unit tests
+        run: pnpm test

--- a/packages/core/src/infrastructure/external-services/npmRegistryService.ts
+++ b/packages/core/src/infrastructure/external-services/npmRegistryService.ts
@@ -157,10 +157,10 @@ interface NpmAuditAdvisory {
 }
 
 /**
- * NPM audit response structure
+ * NPM audit response structure (v1 advisories format)
  */
 interface NpmAuditResponse {
-  advisories?: Record<string, NpmAuditAdvisory>
+  advisories?: Record<string, NpmAuditAdvisory | NpmAuditAdvisory[]>
 }
 
 /**
@@ -648,16 +648,16 @@ export class NpmRegistryService {
     }
 
     try {
-      // Use npm audit API
+      // Use npm v1 bulk advisories API (legacy /-/npm/v1/security/audits retired in pnpm v11)
       const auditData = {
-        name: packageName,
-        version: version,
-        requires: {},
-        dependencies: {},
+        query: {
+          name: packageName,
+          version: version,
+        },
       }
 
       const authConfig = this.getAuthConfig(registryUrl)
-      const response = await npmRegistryFetch('/-/npm/v1/security/audits', {
+      const response = await npmRegistryFetch('/v1/advisories/bulk', {
         method: 'POST',
         body: JSON.stringify(auditData),
         headers: {
@@ -671,19 +671,23 @@ export class NpmRegistryService {
       const auditResult = (await response.json()) as NpmAuditResponse
       const vulnerabilities: SecurityVulnerability[] = []
 
-      // Parse audit results
+      // Parse audit results (new npm v1 advisories format: advisories are arrays per package)
       if (auditResult.advisories) {
-        for (const advisory of Object.values(auditResult.advisories)) {
-          vulnerabilities.push({
-            id: advisory.id.toString(),
-            title: advisory.title,
-            severity: advisory.severity,
-            description: advisory.overview,
-            reference: advisory.url,
-            vulnerable_versions: advisory.vulnerable_versions,
-            patched_versions: advisory.patched_versions,
-            recommendation: advisory.recommendation,
-          })
+        for (const [pkgName, advisories] of Object.entries(auditResult.advisories)) {
+          // Each package name maps to an array of advisories
+          const advisoryList = Array.isArray(advisories) ? advisories : [advisories]
+          for (const advisory of advisoryList) {
+            vulnerabilities.push({
+              id: advisory.id.toString(),
+              title: advisory.title,
+              severity: advisory.severity,
+              description: advisory.overview,
+              reference: advisory.url,
+              vulnerable_versions: advisory.vulnerable_versions,
+              patched_versions: advisory.patched_versions,
+              recommendation: advisory.recommendation,
+            })
+          }
         }
       }
 


### PR DESCRIPTION
## Enhancement: pnpm v11.0.0 Compatibility

### Changes

1. **Update npm audit endpoint**
   - From: `/-/npm/v1/security/audits` (legacy, retired)
   - To: `/v1/advisories/bulk` (new npm v1 format)

2. **Update audit response parsing**
   - New npm v1 advisories return advisories as arrays per package
   - Updated parsing logic to handle `Record<string, Advisory[]>`

3. **Add pnpm v11 CI job**
   - Validates compatibility with pnpm 11.x on Node 22.13.0
   - Runs typecheck, build, and unit tests

4. **engines.pnpm constraint** (from #106)
   - Already added: `">=10 <12"`

### Breaking Changes

- Requires pnpm >= 10 (no change for current users)
- pnpm 12+ will be blocked by engines constraint

### References

- Issue: #108
- pnpm v11 changelog: https://github.com/pnpm/pnpm/releases/tag/v11.0.0-beta.0