### PR TITLE
fix: remove unused NpmAuditResponse interface

### DIFF
--- a/packages/core/src/infrastructure/external-services/npmRegistryService.ts
+++ b/packages/core/src/infrastructure/external-services/npmRegistryService.ts
@@ -157,13 +157,6 @@ interface NpmAuditAdvisory {
 }
 
 /**
- * NPM audit response structure (v1 advisories format)
- */
-interface NpmAuditResponse {
-  advisories?: Record<string, NpmAuditAdvisory | NpmAuditAdvisory[]>
-}
-
-/**
  * NPM download stats response
  */
 interface NpmDownloadStats {


### PR DESCRIPTION
## Summary
Fixes TypeScript error TS6196: NpmAuditResponse declared but never used in `src/infrastructure/external-services/npmRegistryService.ts`.

## Fix
Removed the unused `NpmAuditResponse` interface (7 lines). The interface was declared but never referenced anywhere in the codebase.

## Verification
TypeScript error TS6196 resolved.
